### PR TITLE
Update spanish translation for error message - this field is required

### DIFF
--- a/app/assets/javascripts/jquery.validate.localization/messages_es.js
+++ b/app/assets/javascripts/jquery.validate.localization/messages_es.js
@@ -11,7 +11,7 @@
  * Locale: ES (Spanish; Español)
  */
 $.extend($.validator.messages, {
-	required: "Este campo es obligatorio.",
+	required: "Respuesta requerida.",
 	remote: "Por favor, rellena este campo.",
 	email: "Por favor, escribe una dirección de correo válida.",
 	url: "Por favor, escribe una URL válida.",

--- a/app/assets/javascripts/jquery.validate.localization/messages_es_AR.js
+++ b/app/assets/javascripts/jquery.validate.localization/messages_es_AR.js
@@ -12,7 +12,7 @@
  * Region: AR (Argentina)
  */
 $.extend($.validator.messages, {
-	required: "Este campo es obligatorio.",
+	required: "Respuesta requerida.",
 	remote: "Por favor, completá este campo.",
 	email: "Por favor, escribí una dirección de correo válida.",
 	url: "Por favor, escribí una URL válida.",


### PR DESCRIPTION
**Because:**

The spanish translation for the error message, "This field is required.", has a cleaner translation than that given by Google Translate.

**Pull:**

I changed the translation from `Este campo es obligatorio` to `Respuesta requerida`.
